### PR TITLE
Use uname -m to detect system architecture vs hardcoding x86_64

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -39,13 +39,22 @@ get_tmp_dir() {
 }
 
 get_arch() {
+  arch=$(uname -m)
+  case $arch in
+    aarch64) arch="arm64";;
+    x86_64) arch="x86_64";;
+  esac
+  echo "$arch"
+}
+get_platform() {
   uname
 }
 
 get_download_url() {
   local version="$1"
-  local platform="$(get_arch)"
-  echo "https://github.com/tektoncd/cli/releases/download/v${version}/tkn_${version}_${platform}_x86_64.tar.gz"
+  local platform="$(get_platform)"
+  local arch="$(get_arch)"
+  echo "https://github.com/tektoncd/cli/releases/download/v${version}/tkn_${version}_${platform}_${arch}.tar.gz"
 }
 
 install_tkn $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH


### PR DESCRIPTION
The tekton cli is released in x86_64 and arm64, this change should pull the correct binary for whatever the system host is.


```bash

# Linux_arm64 test
$ asdf plugin add tekton-cli https://github.com/mathew-fleisch/asdf-tekton-cli.git
$ asdf install tekton-cli latest
Downloading Tekton CLI (tkn) from https://github.com/tektoncd/cli/releases/download/v0.21.0/tkn_0.21.0_Linux_arm64.tar.gz to /tmp
Creating bin directory
Copying binary
$ asdf global tekton-cli latest
$ tkn version
Client version: 0.21.0

# Darwin_x86_64 test
$ asdf plugin add tekton-cli https://github.com/mathew-fleisch/asdf-tekton-cli.git
$ asdf install tekton-cli latest
Downloading Tekton CLI (tkn) from https://github.com/tektoncd/cli/releases/download/v0.21.0/tkn_0.21.0_Darwin_x86_64.tar.gz to /var/folders/4z/6b_pfpb50zl2nlmnm3vd2hkc0000gn/T/
Creating bin directory
Copying binary
$ asdf global tekton-cli latest
$ tkn version
Client version: 0.21.0

```